### PR TITLE
Remove line causing Android build to fail

### DIFF
--- a/android/src/main/java/ch/byrds/capacitor/contacts/Contacts.java
+++ b/android/src/main/java/ch/byrds/capacitor/contacts/Contacts.java
@@ -30,8 +30,6 @@ import org.json.JSONObject;
 
 @CapacitorPlugin(
     name = "Contacts",
-    //requestCodes is labeled as legacy in bridge
-    requestCodes = Contacts.REQUEST_CODE,
     permissions = { @Permission(strings = { Manifest.permission.READ_CONTACTS, Manifest.permission.WRITE_CONTACTS }, alias = "contacts") }
 )
 public class Contacts extends Plugin {


### PR DESCRIPTION
This line was determined to be the cause of Android builds failing.

<img width="328" alt="image" src="https://user-images.githubusercontent.com/6100430/153690875-4e19d2f9-0372-4a82-b4d4-d82359b76787.png">

Have not found any ill effects from removing it. 