### PR TITLE
Check for the array length when formatting birthdays on Android

### DIFF
--- a/android/src/main/java/getcapacitor/community/contacts/ContactPayload.java
+++ b/android/src/main/java/getcapacitor/community/contacts/ContactPayload.java
@@ -140,7 +140,7 @@ public class ContactPayload {
                             // Birthday is formatted like "mm-dd"
                             birthday.put("month", parseStrToIntSafe(splittedBirthdayString[0]));
                             birthday.put("day", parseStrToIntSafe(splittedBirthdayString[1]));
-                        } else {
+                        } else if (splittedBirthdayString.length == 3) {
                             // Birthday is formatted like "yyyy-mm-dd"
                             birthday.put("year", parseStrToIntSafe(splittedBirthdayString[0]));
                             birthday.put("month", parseStrToIntSafe(splittedBirthdayString[1]));


### PR DESCRIPTION
On some Samsung phones, I got strings that are not matching the pattern and the application crashes. This way I'm avoiding the error.