### PR TITLE
fix(ios): expose postal addresses correctly in payload

### DIFF
--- a/ios/Plugin/ContactPayload.swift
+++ b/ios/Plugin/ContactPayload.swift
@@ -127,7 +127,7 @@ public class ContactPayload {
 
         // Postal Addresses
         if contact.isKeyAvailable(CNContactPostalAddressesKey) {
-            self.urls = contact.postalAddresses.map { postalAddress in
+            self.postalAddresses = contact.postalAddresses.map { postalAddress in
                 let type = Contacts.postalAddressTypeMap.getKey(postalAddress.label)
                 let formatted = CNPostalAddressFormatter.string(from: postalAddress.value, style: .mailingAddress)
 


### PR DESCRIPTION
iOS was returning addresses as urls and overriding any potential existing urls.