### PR TITLE
Add nickname to name projection on iOS.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -133,14 +133,15 @@ pickContact(options: PickContactOptions) => Promise<PickContactResult>
 
 #### NamePayload
 
-| Prop          | Type                        |
-| ------------- | --------------------------- |
-| **`display`** | <code>string \| null</code> |
-| **`given`**   | <code>string \| null</code> |
-| **`middle`**  | <code>string \| null</code> |
-| **`family`**  | <code>string \| null</code> |
-| **`prefix`**  | <code>string \| null</code> |
-| **`suffix`**  | <code>string \| null</code> |
+| Prop            | Type                        |
+| --------------- | --------------------------- |
+| **`display`**   | <code>string \| null</code> |
+| **`given`**     | <code>string \| null</code> |
+| **`middle`**    | <code>string \| null</code> |
+| **`family`**    | <code>string \| null</code> |
+| **`prefix`**    | <code>string \| null</code> |
+| **`suffix`**    | <code>string \| null</code> |
+| **`nickname`**  | <code>string \| null</code> |
 
 
 #### OrganizationPayload
@@ -270,13 +271,14 @@ pickContact(options: PickContactOptions) => Promise<PickContactResult>
 
 #### NameInput
 
-| Prop         | Type                        |
-| ------------ | --------------------------- |
-| **`given`**  | <code>string \| null</code> |
-| **`middle`** | <code>string \| null</code> |
-| **`family`** | <code>string \| null</code> |
-| **`prefix`** | <code>string \| null</code> |
-| **`suffix`** | <code>string \| null</code> |
+| Prop           | Type                        |
+| -------------- | --------------------------- |
+| **`given`**    | <code>string \| null</code> |
+| **`middle`**   | <code>string \| null</code> |
+| **`family`**   | <code>string \| null</code> |
+| **`prefix`**   | <code>string \| null</code> |
+| **`suffix`**   | <code>string \| null</code> |
+| **`nickname`** | <code>string \| null</code> |
 
 
 #### OrganizationInput

--- a/docs/api.md
+++ b/docs/api.md
@@ -141,7 +141,7 @@ pickContact(options: PickContactOptions) => Promise<PickContactResult>
 | **`family`**    | <code>string \| null</code> |
 | **`prefix`**    | <code>string \| null</code> |
 | **`suffix`**    | <code>string \| null</code> |
-| **`nickname`**  | <code>string \| null</code> |
+| **`nick`**      | <code>string \| null</code> |
 
 
 #### OrganizationPayload
@@ -278,7 +278,7 @@ pickContact(options: PickContactOptions) => Promise<PickContactResult>
 | **`family`**   | <code>string \| null</code> |
 | **`prefix`**   | <code>string \| null</code> |
 | **`suffix`**   | <code>string \| null</code> |
-| **`nickname`** | <code>string \| null</code> |
+| **`nick`**     | <code>string \| null</code> |
 
 
 #### OrganizationInput

--- a/ios/Plugin/ContactPayload.swift
+++ b/ios/Plugin/ContactPayload.swift
@@ -70,6 +70,7 @@ public class ContactPayload {
             self.name["family"] = contact.familyName
             self.name["prefix"] = contact.namePrefix
             self.name["suffix"] = contact.nameSuffix
+            self.name["nickname"] = contact.nickname
         }
 
         // Organization

--- a/ios/Plugin/ContactPayload.swift
+++ b/ios/Plugin/ContactPayload.swift
@@ -70,7 +70,7 @@ public class ContactPayload {
             self.name["family"] = contact.familyName
             self.name["prefix"] = contact.namePrefix
             self.name["suffix"] = contact.nameSuffix
-            self.name["nickname"] = contact.nickname
+            self.name["nick"] = contact.nickname
         }
 
         // Organization

--- a/ios/Plugin/Contacts.swift
+++ b/ios/Plugin/Contacts.swift
@@ -120,8 +120,8 @@ public class Contacts: NSObject {
         if let nameSuffix = contactInput.nameSuffix {
             newContact.nameSuffix = nameSuffix
         }
-        if let nameNickname = contactInput.nameNickname {
-            newContact.nickname = nameNickname
+        if let nameNick = contactInput.nameNick {
+            newContact.nickname = nameNick
         }
 
         // Organization

--- a/ios/Plugin/Contacts.swift
+++ b/ios/Plugin/Contacts.swift
@@ -120,6 +120,9 @@ public class Contacts: NSObject {
         if let nameSuffix = contactInput.nameSuffix {
             newContact.nameSuffix = nameSuffix
         }
+        if let nameNickname = contactInput.nameNickname {
+            newContact.nickname = nameNickname
+        }
 
         // Organization
         if let organizationName = contactInput.organizationName {

--- a/ios/Plugin/CreateContactInput.swift
+++ b/ios/Plugin/CreateContactInput.swift
@@ -9,7 +9,7 @@ public class CreateContactInput {
     public var nameFamily: String?
     public var namePrefix: String?
     public var nameSuffix: String?
-    public var nameNickname: String?
+    public var nameNick: String?
 
     // Organization
     public var organizationName: String?
@@ -45,7 +45,7 @@ public class CreateContactInput {
             self.nameFamily = nameObject["family"] as? String
             self.namePrefix = nameObject["prefix"] as? String
             self.nameSuffix = nameObject["suffix"] as? String
-            self.nameNickname = nameObject["nickname"] as? String
+            self.nameNick = nameObject["nick"] as? String
         }
 
         // Organization

--- a/ios/Plugin/CreateContactInput.swift
+++ b/ios/Plugin/CreateContactInput.swift
@@ -9,6 +9,7 @@ public class CreateContactInput {
     public var nameFamily: String?
     public var namePrefix: String?
     public var nameSuffix: String?
+    public var nameNickname: String?
 
     // Organization
     public var organizationName: String?
@@ -44,6 +45,7 @@ public class CreateContactInput {
             self.nameFamily = nameObject["family"] as? String
             self.namePrefix = nameObject["prefix"] as? String
             self.nameSuffix = nameObject["suffix"] as? String
+            self.nameNickname = nameObject["nickname"] as? String
         }
 
         // Organization

--- a/ios/Plugin/GetContactsProjectionInput.swift
+++ b/ios/Plugin/GetContactsProjectionInput.swift
@@ -70,6 +70,7 @@ public class GetContactsProjectionInput {
             projection.append(CNContactFamilyNameKey as CNKeyDescriptor)
             projection.append(CNContactNamePrefixKey as CNKeyDescriptor)
             projection.append(CNContactNameSuffixKey as CNKeyDescriptor)
+            projection.append(CNContactNicknameKey as CNKeyDescriptor)
         }
 
         // Organization

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -134,6 +134,7 @@ export interface NamePayload {
   family: string | null;
   prefix: string | null;
   suffix: string | null;
+  nickname: string | null;
 }
 
 export interface OrganizationPayload {
@@ -240,6 +241,7 @@ export interface NameInput {
   family?: string | null;
   prefix?: string | null;
   suffix?: string | null;
+  nickname?: string | null;
 }
 
 export interface OrganizationInput {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -134,7 +134,7 @@ export interface NamePayload {
   family: string | null;
   prefix: string | null;
   suffix: string | null;
-  nickname: string | null;
+  nick: string | null;
 }
 
 export interface OrganizationPayload {
@@ -241,7 +241,7 @@ export interface NameInput {
   family?: string | null;
   prefix?: string | null;
   suffix?: string | null;
-  nickname?: string | null;
+  nick?: string | null;
 }
 
 export interface OrganizationInput {


### PR DESCRIPTION
Very straightforward PR, I simply added `nickname` to the `name` projection and mapped Swift side to CNContactNicknameKey. I've no experience with Android, but it could be a tad more work, mapping to `ContactsContract.CommonDataKinds.Nickname.NAME`.

Closes #120 but only for iOS.